### PR TITLE
novo link para o programa do BE

### DIFF
--- a/legislativas/20220130_legislativas/README.md
+++ b/legislativas/20220130_legislativas/README.md
@@ -10,7 +10,7 @@ A disponibilização dos programas num formato standard permitirá também que s
 |---|---|---| --- |
 | Aliança | | | |
 | ALTERNATIVA DEMOCRÁTICA NACIONAL | [Dez 2021](https://adn.com.pt/programa-eleitoral/) | Miguel Gomes | Terminado |
-| Bloco de Esquerda | [Dez 2021](https://programa2022.bloco.org/wp-content/uploads/2021/12/Programa-a-cores-com-pa%CC%81gina-dupla.pdf) | João Saro | Terminado |
+| Bloco de Esquerda | [Dez 2021](https://programa2022.bloco.org/indice/) | João Saro | Terminado |
 | CDS - Partido Popular |  |  | |
 | CDU - Coligação Democráticas Unitária | [Jan. 2022](https://www.cdu.pt/2022/compromisso-eleitoral-do-pcp) | Miguel Gomes| Terminado |
 | CHEGA | [Dez 2021](https://partidochega.pt/programa-eleitoral-legislativas-2022/) | Miguel Gomes | Terminado |


### PR DESCRIPTION
https://programa2022.bloco.org/wp-content/uploads/2021/12/Programa-a-cores-com-página-dupla.pdf está a dar 404, um novo link válido poderá ser https://programa2022.bloco.org/indice/