### PR TITLE
2024: adicionada candidatura do JPP

### DIFF
--- a/legislativas/20240310_legislativas/README.md
+++ b/legislativas/20240310_legislativas/README.md
@@ -16,6 +16,7 @@ A disponibilização dos programas num formato standard permitirá também que s
 | CHEGA | [Fev 2024](https://drive.google.com/file/d/1iaSFszm_8M3dhU2Zf7P2GIsVEfgvMAnU/view?usp=drive_link) | |  |
 | Ergue-te | [Fev 2024](https://drive.google.com/file/d/1GKUP87zt-6LoQ8vpmjKInPnFtGCIQ9Fq/view?usp=drive_link) |  |  |
 | Iniciativa Liberal | [Fev 2024](https://drive.google.com/file/d/14ak-oNVmaPSfRmC9on7BEK5FXjqtMa6Q/view?usp=drive_link)  |  |  |
+| Jutos Pelo Povo | Programa não encontrado | | |
 | LIVRE | [Fev 2024](https://drive.google.com/file/d/1LIEdU4qjSqvl_EUJcOtwt55bK0kCPjAi/view?usp=drive_link) | Waldir P. | NÃO TERMINADO |
 | Movimento Alternativa Socialista | Programa não encontrado |  |  |
 | NOVA DIREITA | [Fev 2024](https://drive.google.com/file/d/1wdtQulXVslAwyKMbxMfCEzz0uULa9RFq/view?usp=drive_link)  | |  |


### PR DESCRIPTION
JPP - Juntos Pelo Povo

Concorre nos círculos eleitorais de Braga, Coimbra, Faro, Lisboa, Porto, Setúbal, Açores, Madeira, Europa e Fora da Europa.

O programa não existe ou não foi encontrado.